### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/tests
+commands.txt
+pytest.ini
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.10-slim
+
+RUN adduser --uid 1000 --gecos '' --gid 0 --disabled-password onepercent && \
+    mkdir -m 775 /opt/onepercent && \
+    apt update && apt install -y default-libmysqlclient-dev pkg-config build-essential netcat-openbsd
+
+COPY --chown=1000:0 requirements.txt /opt/onepercent/
+RUN pip3 install -r /opt/onepercent/requirements.txt && \
+    apt remove -y build-essential && \
+    apt autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/onepercent
+
+COPY --chown=1000:0 . ./
+RUN chmod 774 /opt/onepercent/start.sh
+
+USER 1000
+
+CMD ["./start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:latest
+    environment:
+      MYSQL_ROOT_PASSWORD: 'changeme'
+      MYSQL_DATABASE: 'northcoders'
+      MYSQL_USER: 'northcoders'
+      MYSQL_PASSWORD: 'changeme'
+    ports:
+      - "3306:3306"
+    restart: unless-stopped
+
+  onepercent:
+    build: .
+    image: onepercent
+
+    env_file:
+      - ./.env
+    depends_on:
+      - mysql
+    ports:
+      - 8000:8000
+    environment:
+      SERVER_HOST: 0.0.0.0
+      SERVER_PORT: 8000
+      DB_HOST: mysql
+      DB_PORT: 3306
+      DEBUG: "True"
+    restart: unless-stopped

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+while true; do
+    if nc -z "${DB_HOST}" "${DB_PORT}"; then
+        echo "MySQL ready"
+        break
+    else
+        echo "MySQL not ready yet, waiting"
+        sleep 2
+    fi
+done
+
+echo "Making Migrations"
+python3 manage.py makemigrations
+echo "Running Migrations"
+python3 manage.py migrate
+echo "Starting Server"
+exec python3 manage.py runserver "${SERVER_HOST}:${SERVER_PORT}"


### PR DESCRIPTION
Adds a Docker image for the project and an exemplary docker-compose stack, which spins up a non persisted MySQL Database and the application itself. Will require an existing .env file with the correct values for the application and the password to be set to whatever the MySQL database has configured. 